### PR TITLE
Moving the options card to below the scroll section

### DIFF
--- a/src/components/RootStackNavigator/VariantSelectScreen/CollapsableCards/GameOptionsCard/GameOptionsCard.tsx
+++ b/src/components/RootStackNavigator/VariantSelectScreen/CollapsableCards/GameOptionsCard/GameOptionsCard.tsx
@@ -1,8 +1,8 @@
 import React from "react";
+import { View } from "react-native";
 import { SFC } from "primitives";
 import { LabeledCheckBox } from "ui";
 import { GameOptions } from "game";
-import { CollapsableCard } from "ui/Containers";
 import { TimeOptions } from "components/RootStackNavigator/VariantSelectScreen/CollapsableCards/GameOptionsCard/TimerOptions";
 
 interface Props {
@@ -25,7 +25,7 @@ const GameOptionsCard: SFC<Props> = ({ style, gameOptions, setGameOptions }) => 
     setGameOptions({ ...gameOptions, time });
 
   return (
-    <CollapsableCard title={"Options"} style={style}>
+    <View style={{ ...style, flex: 1 }}>
       <TimeOptions time={gameOptions.time} setTime={setTime} />
       <LabeledCheckBox
         value={!!gameOptions.checkEnabled}
@@ -43,9 +43,9 @@ const GameOptionsCard: SFC<Props> = ({ style, gameOptions, setGameOptions }) => 
         value={!!gameOptions.publicGame}
         setValue={setPublicGame}
         label={"Publicly listed on home screen"}
-        style={{ marginTop: 12, marginBottom: 8 }}
+        style={{ marginTop: 12, marginBottom: 4 }}
       />
-    </CollapsableCard>
+    </View>
   );
 };
 

--- a/src/components/RootStackNavigator/VariantSelectScreen/VariantSelectScreen.tsx
+++ b/src/components/RootStackNavigator/VariantSelectScreen/VariantSelectScreen.tsx
@@ -94,7 +94,6 @@ const VariantSelectScreen: FC = () => {
             activeFilters={activeFilters}
             setActiveFilters={setActiveFilters}
           />
-          <GameOptionsCard gameOptions={gameOptions} setGameOptions={setGameOptions} />
           <AdviceCard
             selectedVariants={selectedVariantsForFormat}
             variantConflicts={variantConflicts}
@@ -113,6 +112,9 @@ const VariantSelectScreen: FC = () => {
           />
           <FormatCard gameOptions={gameOptions} setGameOptions={setGameOptions} />
         </ScrollView>
+        <Divider>
+          <GameOptionsCard gameOptions={gameOptions} setGameOptions={setGameOptions} />
+        </Divider>
         <Divider>
           <ButtonSecondary
             label="Back"


### PR DESCRIPTION
This didn't actually need to be branched off of https://github.com/Meta-Chess/react-prototype/pull/176 but top_bar_removal was making the scroll content larger, and I liked the look of this change on that particular screen.

I think these are particularly important options that a player wants to be aware of pre any game creation. As the sidebar content grows, it became more easy for these options to be hidden. Argument for whether it should also be collapsable, but I didn't like the feel of one collapsable card scrolling under another. Currently I think these options are a good size to not hurt us too much on sidebar real estate.



