### PR TITLE
fix start screen cards overflowing screen on some mobiles

### DIFF
--- a/src/components/RootStackNavigator/StartScreen/UpdateLog/UpdateLog.tsx
+++ b/src/components/RootStackNavigator/StartScreen/UpdateLog/UpdateLog.tsx
@@ -14,11 +14,19 @@ interface Props {
 
 export const UpdateLog: SFC<Props> = ({ updates, onDismiss, windowHeight, style }) => {
   return (
-    <AbsoluteView style={{ backgroundColor: Colors.BLACK.fade(0.2).toString() }}>
+    <AbsoluteView
+      style={{
+        backgroundColor: Colors.BLACK.fade(0.2).toString(),
+        padding: 16,
+      }}
+    >
       <Card
         style={[
           style,
-          { maxHeight: windowHeight * 0.8, width: 400, flexDirection: "column" },
+          {
+            maxHeight: windowHeight * 0.8,
+            flexDirection: "column",
+          },
         ]}
         title={"Recent Updates"}
       >

--- a/src/ui/Containers/Card.tsx
+++ b/src/ui/Containers/Card.tsx
@@ -31,6 +31,7 @@ export const Card: SFC<Props> = ({ title, subtitle, children, style }) => {
 
 const Container = styled(View)`
   width: 400px;
+  max-width: 100%;
   background-color: ${Colors.DARKER.toString()};
   border-color: ${Colors.DARKISH.toString()};
   border-width: 1px;


### PR DESCRIPTION
Looked like this for my Samsung S20 FE:
![344280151_252029903952971_1600767831709149954_n](https://user-images.githubusercontent.com/58617353/236602075-96d554e7-0f84-4d4e-8adc-48c07fe968bb.jpg)

Now corrected to look like:
![344227028_946184076573101_1845738120399007917_n](https://user-images.githubusercontent.com/58617353/236602167-73546e24-10e2-4a2a-8747-327614e18b6b.jpg)
![343969533_753929442947373_1868320669970503084_n](https://user-images.githubusercontent.com/58617353/236602170-8fbd1b19-c094-4e77-bddd-786b544b5a43.jpg)

Might be worth checking how things look on iOS, but I'm quite confident this will be a safe change. Details in the commit.

Also note- 
we’re on a deprecated version of expo, and the Expo Go app no longer works with this version. It seems like a can of worms to upgrade expo, and didn’t look easy to downgrade the expo go app. There are a few easy ways to still test the web app on mobile:

- Emulators for iOS should be fine with the older expo
- Can connect directly to the localhost app on the same network, on mac find local ip with ```ipconfig getifaddr en0``` and on the mobile visit ```http://<local ip>:<port number>``` with the port number of the locally running mchess app
- There are free tools like ngrok, which create an online proxy for the locally hosted app. Cool way to have other developers use someone elses local build online. Ngrok also has a pretty nice request inspector (might be extra handy when we are playing around with login flows)