### PR TITLE
Fixing castling interception

### DIFF
--- a/src/game/Move.ts
+++ b/src/game/Move.ts
@@ -49,6 +49,20 @@ export function movesAreEqual(m1: Move, m2: Move): boolean {
         delta.pieceId === m2.pieceDeltas[index].pieceId &&
         delta.path.getEnd() === m2.pieceDeltas[index].path.getEnd(),
       true
-    )
+    ) &&
+    moveCapturesAreEqual(m1.captures, m2.captures)
   );
+}
+
+function moveCapturesAreEqual(
+  m1captures: CaptureData[] | undefined,
+  m2captures: CaptureData[] | undefined
+): boolean {
+  const m1CapturedPieceIds = new Set(
+    (m1captures || []).flatMap((capture) => capture.pieceIds.map((pId) => pId))
+  );
+  const m2CapturedPieceIds = new Set(
+    (m2captures || []).flatMap((capture) => capture.pieceIds.map((pId) => pId))
+  );
+  return isEqual(m1CapturedPieceIds, m2CapturedPieceIds);
 }

--- a/src/game/Move.ts
+++ b/src/game/Move.ts
@@ -58,11 +58,23 @@ function moveCapturesAreEqual(
   m1captures: CaptureData[] | undefined,
   m2captures: CaptureData[] | undefined
 ): boolean {
-  const m1CapturedPieceIds = new Set(
-    (m1captures || []).flatMap((capture) => capture.pieceIds.map((pId) => pId))
+  if (!m1captures && !m2captures) {
+    return true;
+  }
+
+  if (!m1captures || !m2captures) {
+    return false;
+  }
+
+  return (
+    m1captures.length === m2captures.length &&
+    m1captures.reduce<boolean>(
+      (acc, capture, index) =>
+        acc &&
+        capture.at === m2captures[index].at &&
+        capture.capturer === m2captures[index].capturer &&
+        isEqual(capture.pieceIds, m2captures[index].pieceIds),
+      true
+    )
   );
-  const m2CapturedPieceIds = new Set(
-    (m2captures || []).flatMap((capture) => capture.pieceIds.map((pId) => pId))
-  );
-  return isEqual(m1CapturedPieceIds, m2CapturedPieceIds);
 }

--- a/src/game/Pather/Pather.ts
+++ b/src/game/Pather/Pather.ts
@@ -215,8 +215,9 @@ export class Pather {
       !gait.mustCapture && (gait.phaser || (!enemiesPresent && !friendliesPresent));
     const canCaptureNormally =
       !gait.mustNotCapture && (!friendliesPresent || gait.phaser) && enemiesPresent;
-    const mayMakeOptionalCapture =
-      !gait.mustNotCapture && (!friendliesPresent || gait.phaser);
+    const mayMakeOptionalCaptureWithoutCapturingNormally =
+      !gait.mustNotCapture && (!(friendliesPresent || enemiesPresent) || gait.phaser);
+    const mayMakeOptionalCaptureWithCapturingNormally = canCaptureNormally;
 
     // what moves are theoretically possible?
     const passiveMove = canMovePassively ? move : undefined;
@@ -234,29 +235,32 @@ export class Pather {
           ],
         }
       : undefined;
-    const optionalCaptureMove: Move | undefined =
-      mayMakeOptionalCapture && !!optionalCapturePossible
+    const optionalCaptureWithoutCaptureMove: Move | undefined =
+      mayMakeOptionalCaptureWithoutCapturingNormally && !!optionalCapturePossible
         ? {
             ...clone(move),
             captures: [{ ...optionalCapturePossible, capturer: move.playerName }],
           }
         : undefined;
-    const optionalCaptureAndCaptureMove =
-      optionalCaptureMove?.captures && captureMove?.captures
+    const optionalCaptureWithCaptureMove =
+      mayMakeOptionalCaptureWithCapturingNormally &&
+      !!optionalCapturePossible &&
+      captureMove?.captures
         ? {
             ...clone(move),
-            captures: [...captureMove.captures, ...optionalCaptureMove.captures],
+            captures: [
+              ...captureMove.captures,
+              { ...optionalCapturePossible, capturer: move.playerName },
+            ],
           }
         : undefined;
 
-    const possibleMoves = [passiveMove, captureMove, optionalCaptureAndCaptureMove];
-
-    const canMakeOptionalCaptureWithoutNormalCapture =
-      optionalCaptureMove && (!captureMove || gait.phaser);
-    if (canMakeOptionalCaptureWithoutNormalCapture)
-      possibleMoves.push(optionalCaptureMove);
-
-    return possibleMoves.filter(isPresent);
+    return [
+      passiveMove,
+      captureMove,
+      optionalCaptureWithoutCaptureMove,
+      optionalCaptureWithCaptureMove,
+    ].filter(isPresent);
   }
 
   go({ from, direction }: { from: Square; direction: Direction }): Square[] {

--- a/src/game/Pather/Pather.ts
+++ b/src/game/Pather/Pather.ts
@@ -249,12 +249,14 @@ export class Pather {
           }
         : undefined;
 
-    return [
-      passiveMove,
-      captureMove,
-      optionalCaptureMove,
-      optionalCaptureAndCaptureMove,
-    ].filter(isPresent);
+    const possibleMoves = [passiveMove, captureMove, optionalCaptureAndCaptureMove];
+
+    const canMakeOptionalCaptureWithoutNormalCapture =
+      optionalCaptureMove && (!captureMove || gait.phaser);
+    if (canMakeOptionalCaptureWithoutNormalCapture)
+      possibleMoves.push(optionalCaptureMove);
+
+    return possibleMoves.filter(isPresent);
   }
 
   go({ from, direction }: { from: Square; direction: Direction }): Square[] {

--- a/src/game/tests/situations/interception.test.ts
+++ b/src/game/tests/situations/interception.test.ts
@@ -1,0 +1,102 @@
+import { toLocation } from "utilities";
+import { GameMaster } from "game/GameMaster";
+import { calculateGameOptions } from "game/variantAndRuleProcessing/calculateGameOptions";
+import { PieceName, PlayerName } from "game/types";
+
+describe("Given interception", () => {
+  let gameMaster: GameMaster;
+  beforeEach(() => {
+    gameMaster = new GameMaster(
+      ...GameMaster.processConstructorInputs({
+        gameOptions: calculateGameOptions(
+          {
+            checkEnabled: false,
+          },
+          []
+        ),
+      })
+    );
+  });
+  it("A king castling through an opposing bishop attack with no-check can be optionally intercepted", () => {
+    // White pawn to E4
+    gameMaster.handleSquarePressed(toLocation({ rank: 2, file: 5 }));
+    gameMaster.handleSquarePressed(toLocation({ rank: 4, file: 5 }));
+
+    // Black pawn to B6
+    gameMaster.handleSquarePressed(toLocation({ rank: 7, file: 2 }));
+    gameMaster.handleSquarePressed(toLocation({ rank: 6, file: 2 }));
+
+    // White bishop to A6
+    gameMaster.handleSquarePressed(toLocation({ rank: 1, file: 6 }));
+    gameMaster.handleSquarePressed(toLocation({ rank: 6, file: 1 }));
+
+    // Black bishop captures on A6, is now attacking the castling path at F1
+    gameMaster.handleSquarePressed(toLocation({ rank: 8, file: 3 }));
+    gameMaster.handleSquarePressed(toLocation({ rank: 6, file: 1 }));
+
+    // White knight to F3, white now free to castle
+    gameMaster.handleSquarePressed(toLocation({ rank: 1, file: 7 }));
+    gameMaster.handleSquarePressed(toLocation({ rank: 3, file: 6 }));
+
+    // Black passing move pawn to H6
+    gameMaster.handleSquarePressed(toLocation({ rank: 7, file: 8 }));
+    gameMaster.handleSquarePressed(toLocation({ rank: 6, file: 8 }));
+
+    // White castles kingside
+    gameMaster.handleSquarePressed(toLocation({ rank: 1, file: 5 }));
+    gameMaster.handleSquarePressed(toLocation({ rank: 1, file: 7 }));
+    // Verify rook at F1
+    expect(
+      gameMaster.game.board.getPiecesAt(toLocation({ rank: 1, file: 6 })).length
+    ).toEqual(1);
+    const whiteRook = gameMaster.game.board.getPiecesAt(
+      toLocation({ rank: 1, file: 6 })
+    )[0];
+    expect(whiteRook.name).toEqual(PieceName.Rook);
+    // Verify king at G1
+    expect(
+      gameMaster.game.board.getPiecesAt(toLocation({ rank: 1, file: 7 })).length
+    ).toEqual(1);
+    const whiteKing = gameMaster.game.board.getPiecesAt(
+      toLocation({ rank: 1, file: 7 })
+    )[0];
+    expect(whiteKing.name).toEqual(PieceName.King);
+
+    // Black bishop can capture either just the rook, or the rook and the king
+    gameMaster.handleSquarePressed(toLocation({ rank: 6, file: 1 }));
+    const captureMoves = gameMaster.allowableMoves.filter(
+      (move) => (move?.captures?.length || 0) > 0
+    );
+    expect(captureMoves.length).toEqual(2);
+    const rookCapture = captureMoves.filter(
+      (move) => (move?.captures?.length || 0) === 1
+    )[0];
+    expect(rookCapture.captures?.[0]?.pieceIds[0]).toEqual(whiteRook.id);
+
+    const rookAndKingCapture = captureMoves.filter(
+      (move) => (move?.captures?.length || 0) === 2
+    )[0];
+    expect(rookAndKingCapture.captures).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ at: "R1F6", pieceIds: [whiteRook.id] }),
+        expect.objectContaining({ at: "R1F6", pieceIds: [whiteKing.id] }),
+      ])
+    );
+
+    // Capturing the rook and the king
+    gameMaster.unselectAllPieces();
+    gameMaster.game.doMove(rookAndKingCapture);
+    // Bishop should now be at F1
+    const piecesAtF1 = gameMaster.game.board.getPiecesAt(
+      toLocation({ rank: 1, file: 6 })
+    );
+    expect(piecesAtF1.length).toEqual(1);
+    expect(piecesAtF1[0].name).toEqual(PieceName.Bishop);
+    expect(piecesAtF1[0].owner).toEqual(PlayerName.Black);
+    // No king on G1
+    const piecesAtG1 = gameMaster.game.board.getPiecesAt(
+      toLocation({ rank: 1, file: 7 })
+    );
+    expect(piecesAtG1.length).toEqual(0);
+  });
+});


### PR DESCRIPTION
turns out this was 2 issues, which Ive provided fixes for:
- multiple capture moves were generated, but not provided to the DisambiguationModal due to being filtered out as equalMoves, because the equalMove function was not considering captures (the first move was always picked, which was the non-optional-capture move)
- the optional capture move was allowed without the normal capture- now this is only allowed when the piece is a phaser, or if the normal capture is invalid while the optional capture isn't 

These changes mean we can now choose to not intercept if we have another move to the square, which I think should be a param at some point