### PR TITLE
subtle push bug

### DIFF
--- a/src/game/CompactRules/rules/push.ts
+++ b/src/game/CompactRules/rules/push.ts
@@ -129,7 +129,7 @@ function amendLeadingPushMoves({
   return leadingMoves.map((move) => {
     // TODO (Extension): handling moves which initially have multiple pieceDeltas
     const leaderPath = move.pieceDeltas[0].path.getPath();
-    const orderedPiecesFromLeader = [...followers.reverse(), pusher];
+    const orderedPiecesFromLeader = [pusher, ...followers].reverse();
 
     const amendingDeltas = [];
     let succeedingPath = leaderPath;


### PR DESCRIPTION
nasty .reverse was messing with the actual followers list, and in some cases would flip the middle members and make all the constructed deltas incorrect

it might have to do with both the parity of gaits and piece chain length- but popped up a bunch on hex: e.g. pushing the 10th file white pawn on hex, double pushing the black 8th file pawn (so that there is a 4 length piece chain from the queen), make a passing move for white, push the long piece chain with the queen, and itll be not working right pre-this fix