### PR TITLE
Spherical + more reroutes

### DIFF
--- a/src/navigation/NavigatorParamList.ts
+++ b/src/navigation/NavigatorParamList.ts
@@ -7,6 +7,7 @@ export interface NavigatorParamList extends ParamListBase {
   [Screens.GameScreen]?: {
     gameOptions?: GameOptions;
     roomId?: string;
+    namedGameMode?: string;
   };
   [Screens.StartScreen]: undefined;
   [Screens.VariantSelectScreen]?: {

--- a/src/navigation/linking.ts
+++ b/src/navigation/linking.ts
@@ -1,7 +1,10 @@
-import { LinkingOptions } from "@react-navigation/native";
+import { LinkingOptions, getStateFromPath } from "@react-navigation/native";
 import { Screens } from "./Screens";
 import { GameOptions } from "game/types";
 import { NavigatorParamList } from "navigation/NavigatorParamList";
+import { FormatName } from "game/formats";
+import { FutureVariantName } from "game/variants";
+import { calculateGameOptions } from "game/variantAndRuleProcessing";
 
 export const linking: LinkingOptions<NavigatorParamList> = {
   prefixes: [],
@@ -10,7 +13,7 @@ export const linking: LinkingOptions<NavigatorParamList> = {
       [Screens.AboutScreen]: { path: "about" },
       [Screens.GameScreen]: {
         // `/:` precedes a route param name. `?` marks the preceding name as optional
-        path: "game/:roomId?/:gameOptions?",
+        path: "game/:roomId?/:gameOptions?/:namedGameMode?",
         stringify: {
           roomId: (roomId?: string): string => roomId || "",
           gameOptions: (_gameOptions: GameOptions): string => "", // Hide game options - they're ugly
@@ -24,5 +27,50 @@ export const linking: LinkingOptions<NavigatorParamList> = {
         },
       },
     },
+  },
+  getStateFromPath(path, options) {
+    if (Object.keys(pathToNamedGameMode).includes(path)) {
+      return {
+        routes: [
+          {
+            name: Screens.GameScreen,
+            params: namedGameModeParams[pathToNamedGameMode[path]],
+          },
+        ],
+      };
+    }
+
+    return getStateFromPath(path, options);
+  },
+};
+
+enum NamedGameMode {
+  spherical = "spherical",
+}
+const pathToNamedGameMode = Object.keys(NamedGameMode).reduce((acc, gameMode) => {
+  acc[`/${gameMode}`] = gameMode as NamedGameMode;
+  acc[`/game/${gameMode}`] = gameMode as NamedGameMode;
+  return acc;
+}, {} as { [key: string]: NamedGameMode });
+
+const namedGameModeParams: {
+  [key in NamedGameMode]: NavigatorParamList[Screens.GameScreen];
+} = {
+  [NamedGameMode.spherical]: {
+    gameOptions: calculateGameOptions(
+      {
+        checkEnabled: true,
+        online: false,
+        publicGame: false,
+        numberOfPlayers: 2,
+        format: "variantComposition" as FormatName,
+        baseVariants: [],
+        ruleNamesWithParams: {},
+        time: undefined,
+      },
+      ["spherical"] as FutureVariantName[]
+    ),
+    roomId: undefined,
+    namedGameMode: "spherical",
   },
 };


### PR DESCRIPTION
Allowing a local game to be started for select variants by visiting certain paths:
- spherical: /sphere /spherical /game/sphere -> /game/spherical
- cylindrical: /cylinder /cylindrical /game/cylinder -> /game/cylindrical
- mobius: /mobius -> /game/mobius
- toroidal: /torus /toroidal /game/torus -> /game/toroidal