### PR TITLE
Fixed EnPassant Bug (PR also contains local debugging walkthrough)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,24 @@
 An expo web and mobile app for playing chess variants, their combinations, and formats of variants.
 
 ## Setup
+
 TODO: Add more detailed installation instructions
+
 1. Make sure npm and yarn have been installed on your machine
 2. `yarn install`
 
 ## Start
+
 `yarn web` or `yarn ios` you may need to run `yarn add expo-cli` as well.
 
 ## Testing
+
 `yarn test` or `yarn test <test_name_fragment>`
 
 #### Test writing helpers
+
 To use of the test writing helper comments:
+
 1. Search for `TEST WRITING HELPER COMMENT` and uncomment each of these lines
 2. Start a new game from the variant select screen
 3. Do the moves/presses of the situation you want to test
@@ -24,19 +30,26 @@ To use of the test writing helper comments:
 7. Add expectations specific to the scenario you're testing
 8. Revert the changes to the files with the `TEST WRITING HELPER COMMENT` lines, restoring them to commented single-lines
 
+## Debugging
+
+See the description of https://github.com/Meta-Chess/react-prototype/pull/191 for a guide to setup debugging for VS Code
 
 ## Design
 
 #### Interruption points and rules
+
 TODO: info about adding a new interruption point
 The constant `ruleOrderPerInterruptionPoint` determines execution order for rules at the mentioned interruption point.
+
 1. Found in the file `CompactRules.ts`
 2. The order rules are written in is the order they will be executed in.
 3. Rules are referenced by their name, `theRest` referes to all the rules not mentioned in the list.
 4. If an interuption point is not listed below then the rules will have default ordering for that interruption point.
 
 #### Events
+
 TODO
 
 #### Game master, game provider, game, and online game master
+
 TODO

--- a/src/game/CompactRules/rules/castling.ts
+++ b/src/game/CompactRules/rules/castling.ts
@@ -11,6 +11,7 @@ import {
 import { Piece } from "game/Board";
 import { ParameterRule } from "game";
 import { range } from "utilities";
+import { InterceptionConditionType } from "game/types/InterceptionCondition";
 
 export const castling: ParameterRule<"castling"> = ({
   "Active Piece Steps": activePieceSteps,
@@ -106,10 +107,8 @@ export const castling: ParameterRule<"castling"> = ({
         playerName: activePiece.owner,
         data: {
           interceptable: true,
-          interceptionCondition: (piece: Piece): boolean => {
-            const originalOwner = activePiece.owner;
-            return piece.owner !== originalOwner;
-          },
+          interceptionConditionType: InterceptionConditionType.Generic,
+          interceptionConditionBuilderParams: { originalOwner: activePiece.owner },
           interceptableAtStart: true,
         },
       })

--- a/src/game/CompactRules/rules/interception.ts
+++ b/src/game/CompactRules/rules/interception.ts
@@ -1,5 +1,6 @@
 import { TokenName } from "game/types";
 import { PostMove, TrivialParameterRule } from "../CompactRules";
+import { interceptionConditionBuilders } from "game/types/InterceptionCondition";
 
 export const interception: TrivialParameterRule = () => ({
   title: "Interception",
@@ -16,6 +17,19 @@ export const interception: TrivialParameterRule = () => ({
         ?.path.getPath()
         .slice(start, -1)
         .forEach((location) => {
+          const interceptionConditionType = move.data?.interceptionConditionType;
+          const interceptionConditionBuildParams =
+            move.data?.interceptionConditionBuilderParams;
+          if (
+            interceptionConditionType === undefined ||
+            interceptionConditionBuildParams === undefined
+          )
+            return;
+
+          const interceptionCondition = interceptionConditionBuilders[
+            interceptionConditionType
+          ](interceptionConditionBuildParams);
+
           const interceptionToken = {
             name: TokenName.CaptureToken,
             expired: (turn: number): boolean => {
@@ -23,7 +37,7 @@ export const interception: TrivialParameterRule = () => ({
             },
             data: {
               pieceId: move.pieceId,
-              condition: move.data?.interceptionCondition,
+              condition: interceptionCondition,
             },
           };
 

--- a/src/game/CompactRules/rules/pawnDoubleStep.ts
+++ b/src/game/CompactRules/rules/pawnDoubleStep.ts
@@ -8,6 +8,7 @@ import {
 } from "../CompactRules";
 import { pawnDoubleStepToken } from "../constants";
 import { isPresent } from "utilities";
+import { InterceptionConditionType } from "game/types/InterceptionCondition";
 
 export const pawnDoubleStep: TrivialParameterRule = () => ({
   title: "Pawn Double Step",
@@ -50,9 +51,8 @@ function doubleStep(originalPiece: Piece): (originalGait: Gait) => Gait {
     pattern: [...originalGait.pattern, ...originalGait.pattern],
     data: {
       interceptable: true,
-      interceptionCondition: (piece: Piece): boolean => {
-        return piece.name === PieceName.Pawn && piece.owner !== originalOwner;
-      },
+      interceptionConditionType: InterceptionConditionType.PawnDoubleStep,
+      interceptionConditionBuilderParams: { originalOwner },
     },
   });
 }

--- a/src/game/Move.ts
+++ b/src/game/Move.ts
@@ -1,12 +1,17 @@
-import { Piece } from "game/Board";
 import { Path } from "game/Pather/Path";
 import { PieceName, PlayerName, TimestampMillis } from "game/types";
 import { isEqual } from "lodash";
 import { Direction } from "game/types";
+import type { GaitData } from "game/types";
+import {
+  InterceptionConditionType,
+  InterceptionConditionBuilderParams,
+} from "game/types/InterceptionCondition";
 
-export interface MoveData {
+export interface MoveData extends GaitData {
   interceptable?: boolean;
-  interceptionCondition?: (piece: Piece) => boolean;
+  interceptionConditionType?: InterceptionConditionType;
+  interceptionConditionBuilderParams?: InterceptionConditionBuilderParams;
   interceptableAtStart?: boolean;
   linearMoverDirection?: Direction;
 }
@@ -17,6 +22,7 @@ export interface CaptureData {
   capturer: PlayerName;
 }
 
+// NOTE: the Move type and hence any attributes like MoveData, must remain JSON serializable/parsable (for online play). e.g. no functions
 export interface Move {
   pieceId: string;
   location: string;

--- a/src/game/types/InterceptionCondition.ts
+++ b/src/game/types/InterceptionCondition.ts
@@ -1,0 +1,29 @@
+import type { Piece } from "game/Board";
+import { PieceName, PlayerName } from "./types";
+
+export enum InterceptionConditionType {
+  PawnDoubleStep,
+  Generic,
+}
+export type InterceptionCondition = (piece: Piece) => boolean;
+
+export interface InterceptionConditionBuilderParams {
+  originalOwner: PlayerName;
+}
+
+export const interceptionConditionBuilders: {
+  [key in InterceptionConditionType]: (
+    params: InterceptionConditionBuilderParams
+  ) => InterceptionCondition;
+} = {
+  [InterceptionConditionType.PawnDoubleStep]:
+    (params) =>
+    (piece: Piece): boolean => {
+      return piece.name === PieceName.Pawn && piece.owner !== params.originalOwner;
+    },
+  [InterceptionConditionType.Generic]:
+    (params) =>
+    (piece: Piece): boolean => {
+      return piece.owner !== params.originalOwner;
+    },
+};

--- a/src/game/types/index.ts
+++ b/src/game/types/index.ts
@@ -1,3 +1,4 @@
 export * from "./types";
 export * from "./Direction";
 export * from "./ruleParamTypeGuard";
+export * from "./InterceptionCondition";

--- a/src/game/types/types.ts
+++ b/src/game/types/types.ts
@@ -4,10 +4,16 @@ import { FutureVariantName, Piece, VariantName } from "game";
 import { FormatName } from "game/formats";
 import { getValues } from "utilities";
 import { RuleNamesWithParams } from "game/CompactRules";
+import {
+  InterceptionCondition,
+  InterceptionConditionType,
+  InterceptionConditionBuilderParams,
+} from "game/types/InterceptionCondition";
 
 export interface GaitData {
   interceptable?: boolean;
-  interceptionCondition?: (piece: Piece) => boolean;
+  interceptionConditionType?: InterceptionConditionType;
+  interceptionConditionBuilderParams?: InterceptionConditionBuilderParams;
   linearMoverDirection?: Direction;
 }
 
@@ -99,7 +105,7 @@ interface TokenData {
   history?: string[];
   shape?: SquareShape;
   pieceId?: string;
-  condition?: (piece: Piece) => boolean;
+  condition?: InterceptionCondition;
   type?: AnimationType; // TODO: type is a special word, maybe this key should be animationType?
   createdAt?: number;
   duration?: number;


### PR DESCRIPTION
To reproduce the bug:
- must be an online game; can just play regular chess
- set up the position so that it is white's turn, and white should be able to enpassant
- white will not be able to enpassant, black will think white can enpassant

Fix:
move and gait data are now JSON serialisable. enpassant bug was caused by the token condition being undefined, due to the MoveData interceptionCondition being a function which was not serialisable. also extending MoveData from GaitData, as this is implicit by our use of GaitData in Pather

Note:
- we should have some kind of set-up for online-type tests, but it was non-trivial, and didn't have the energy this time around

Debugging is pretty easy with VSCode:
- open a JavaScript Debug Terminal
![image](https://github.com/user-attachments/assets/af2de34b-b324-4081-8444-c2e29cf80e98)
- yarn web in the new terminal
- in the debug section > Run and Debug, Launch Chrome against localhost
![image](https://github.com/user-attachments/assets/7cd2440c-f9e6-4582-810d-7fadf36f1bcf)
- might need to update the launch.json to set url to the appropriate matching localhost (click the gear to the right of Run and Debug to open)
![image](https://github.com/user-attachments/assets/6bd836b0-d5d2-4595-8e15-0d79a8f876ef)
- writing `debugger;` lines acts as a breakpoint- and can be conditionally run using regular code logic
- run a particular test in debug mode with `yarn test <testFile> --watch --watchAll=false`; watchAll=false seems to fix an issue where too many files are being processed


