### PR TITLE
supporting more special mode routes

### DIFF
--- a/src/components/RootStackNavigator/VariantSelectScreen/VariantSelectScreen.tsx
+++ b/src/components/RootStackNavigator/VariantSelectScreen/VariantSelectScreen.tsx
@@ -40,6 +40,7 @@ const VariantSelectScreen: FC = () => {
   const [gameOptions, setGameOptions] = useState<GameOptions>({
     ...defaultGameOptions,
     online: playWithFriends,
+    time: playWithFriends ? 300000 : defaultGameOptions.time,
   });
 
   const [activeFilters, setActiveFilters] = useState<Filter[]>([]);

--- a/src/game/variantAndRuleProcessing/calculateGameOptions.ts
+++ b/src/game/variantAndRuleProcessing/calculateGameOptions.ts
@@ -37,5 +37,5 @@ export const defaultGameOptions = {
   checkEnabled: true,
   online: false,
   publicGame: false,
-  time: 300000,
+  time: undefined,
 } as const;

--- a/src/navigation/NamedGameMode.ts
+++ b/src/navigation/NamedGameMode.ts
@@ -44,20 +44,30 @@ export const pathToParams = Object.keys(NamedGameMode).reduce((acc, gameMode) =>
   const onlineGameOptions = { ...gameOptions, online: true, time: 300000 };
   const mode = namedGameMode;
 
+  // TODO: clean up the repetition below
   acc[`/${gameMode}`] = { gameOptions, mode };
-  // handling refreshing with query param
-  acc[`/game/?mode=${gameMode}`] = { gameOptions, mode };
   // online route doesn't need a mode param- it has a lobby on refresh
   acc[`/${gameMode}/online`] = {
     gameOptions: onlineGameOptions,
   };
+  // also catching trailing slash- the behavior is different in prod, Amplify(?) would map /mode -> /mode/
+  acc[`/${gameMode}/`] = { gameOptions, mode };
+  acc[`/${gameMode}/online/`] = {
+    gameOptions: onlineGameOptions,
+  };
+  // handling refreshing with query param
+  acc[`/game/?mode=${gameMode}`] = { gameOptions, mode };
 
   alternamePathNamings[namedGameMode]?.forEach((pathName) => {
     acc[`/${pathName}`] = { gameOptions, mode };
-    acc[`/game/?mode=${pathName}`] = { gameOptions, mode };
     acc[`/${pathName}/online`] = {
       gameOptions: onlineGameOptions,
     };
+    acc[`/${pathName}/`] = { gameOptions, mode };
+    acc[`/${pathName}/online/`] = {
+      gameOptions: onlineGameOptions,
+    };
+    acc[`/game/?mode=${pathName}`] = { gameOptions, mode };
   });
   return acc;
 }, {} as { [key: string]: NavigatorParamList[Screens.GameScreen] });


### PR DESCRIPTION
prod routing behaved differently from local, catching the trailing slashes should fix the problem- may be worth coming back and looking at the infrastructure routing (see Amplify/R53)